### PR TITLE
Add idp_hint asserting micro service

### DIFF
--- a/example/assert_hint.yaml.example
+++ b/example/assert_hint.yaml.example
@@ -1,0 +1,6 @@
+module: svs.assert_hint.AssertHint
+name: AssertHint
+config:
+    internal_attribute: 'idp_used'
+
+

--- a/src/svs/assert_hint.py
+++ b/src/svs/assert_hint.py
@@ -1,0 +1,50 @@
+"""
+Micro Service that asserts the requested idp_hint
+"""
+import hashlib
+import json
+from urllib.parse import parse_qs
+
+import logging
+
+from satosa.internal_data import InternalResponse
+from satosa.micro_services.base import ResponseMicroService
+
+logger = logging.getLogger('satosa')
+
+class AssertHint(ResponseMicroService):
+    """
+    idp_hint asserting micro_service
+    """
+
+    def __init__(self, config, internal_attributes, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.internal_attribute = config.get('internal_attribute', 'idp_used')
+        logger.info("AssertHint micro_service is active %s" % self.internal_attribute)
+
+    def process(self, context, internal_response):
+        try:
+            oidc_request = context.state['InAcademia']['oidc_request']
+            params = parse_qs(oidc_request)
+            if 'idp_hint' in params.keys():
+                idp_hint_key = params['idp_hint'][0]
+            else:
+                # TODO
+                # This will fail if the claims are requested as part
+                # of a POST body. How to handle?
+                claims = json.loads(params['claims'][0])
+                idp_hint_key = claims['id_token']['idp_hint']['value']
+        except Exception as e:
+                logger.info("AssertHint Exception: %s" % e)
+                idp_hint_key = None
+
+        if idp_hint_key != None:
+            issuer = internal_response.auth_info.issuer
+            logger.info("AssertHint issuer: %s" % issuer)
+
+            # This from inacademia-hinting code
+            issuer_hash = hashlib.sha1(issuer.encode('utf-8')).hexdigest()
+            internal_response.attributes[self.internal_attribute] = [issuer_hash]
+            logger.info("AssertHint requested idp_hint: %s" % idp_hint_key)
+
+        return super().process(context, internal_response)

--- a/src/svs/assert_hint.py
+++ b/src/svs/assert_hint.py
@@ -2,15 +2,23 @@
 Micro Service that asserts the requested idp_hint
 """
 import hashlib
-import json
-from urllib.parse import parse_qs
-
 import logging
 
 from satosa.internal_data import InternalResponse
 from satosa.micro_services.base import ResponseMicroService
 
 logger = logging.getLogger('satosa')
+
+def inacademia_hinting_hash(data):
+    """
+    Hash data the same way this is done in the inacademia-hinting code.
+
+    This code should not be changed on its own - if needed, it should be
+    changed in-sync with the inacademia-hinting code.
+    """
+    raw = data.encode("utf-8") if isinstance(data, str) else data
+    hash = hashlib.sha1(raw).hexdigest()
+    return hash
 
 class AssertHint(ResponseMicroService):
     """
@@ -30,8 +38,7 @@ class AssertHint(ResponseMicroService):
             issuer = internal_response.auth_info.issuer
             logger.info("AssertHint issuer: %s" % issuer)
 
-            # This from inacademia-hinting code
-            issuer_hash = hashlib.sha1(issuer.encode('utf-8')).hexdigest()
+            issuer_hash = inacademia_hinting_hash(issuer)
             internal_response.attributes[self.internal_attribute] = [issuer_hash]
 
         return super().process(context, internal_response)

--- a/src/svs/assert_hint.py
+++ b/src/svs/assert_hint.py
@@ -23,28 +23,15 @@ class AssertHint(ResponseMicroService):
         logger.info("AssertHint micro_service is active %s" % self.internal_attribute)
 
     def process(self, context, internal_response):
-        try:
-            oidc_request = context.state['InAcademia']['oidc_request']
-            params = parse_qs(oidc_request)
-            if 'idp_hint' in params.keys():
-                idp_hint_key = params['idp_hint'][0]
-            else:
-                # TODO
-                # This will fail if the claims are requested as part
-                # of a POST body. How to handle?
-                claims = json.loads(params['claims'][0])
-                idp_hint_key = claims['id_token']['idp_hint']['value']
-        except Exception as e:
-                logger.info("AssertHint Exception: %s" % e)
-                idp_hint_key = None
+        idp_hint_key = context.state['InAcademia'].get('idp_hint_key', None)
+        logger.debug("AssertHint requested idp_hint: %s" % idp_hint_key)
 
-        if idp_hint_key != None:
+        if idp_hint_key is not None:
             issuer = internal_response.auth_info.issuer
             logger.info("AssertHint issuer: %s" % issuer)
 
             # This from inacademia-hinting code
             issuer_hash = hashlib.sha1(issuer.encode('utf-8')).hexdigest()
             internal_response.attributes[self.internal_attribute] = [issuer_hash]
-            logger.info("AssertHint requested idp_hint: %s" % idp_hint_key)
 
         return super().process(context, internal_response)

--- a/src/svs/inacademia_frontend.py
+++ b/src/svs/inacademia_frontend.py
@@ -112,6 +112,9 @@ class InAcademiaFrontend(OpenIDConnectFrontend):
             except KeyError:
                 idp_hint_key = None
         if idp_hint_key:
+            # We could suffice with idp_hint = true, but we may want
+            # to act differently on mismatches in the future?
+            context.state['InAcademia']['idp_hint_key'] = idp_hint_key
             entity_id = self.entity_id_map.get(idp_hint_key, None)
             if entity_id:
                 #Base64 encode the URL because SATOSA's saml2 backend expects it so


### PR DESCRIPTION
This PR needs additional configuration:
An assert_hint.yaml config file:
```
module: svs.assert_hint.AssertHint
name: AssertHint
config:
    internal_attribute: 'idp_used'
```
And an extra plugin line in satosa proxy_conf.yaml:
```
  ...
  - 'plugins/assert_hint.yaml'
  ...
```
The cdb.json RP configuration to be extended with idp_hint as allowed claim:
```
  "rp": {
    "allowed_claims": [
      "domain",
      "country",
      "institution",
      "idp_hint"
    ],
    ...
```
And internal_attributes.yaml to be extended with an oidc idp_hint claim, based on the internal attribute configured in the assert_hint.yaml configuration file:
```
  ...
  idp_used:
    openid: [idp_hint]
```
