### PR TITLE
Log list of received attributes from IdP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to InAcademia SVS will be documented in this file.
 
 ## [Unreleased]
+## 2020-11-27
+- Add logline for received IdP attributes to backend
 ## 2020-11-24
 - Updated translations
 ## 2020-11-03

--- a/src/svs/inacademia_backend.py
+++ b/src/svs/inacademia_backend.py
@@ -12,6 +12,7 @@ from satosa.exception import SATOSAAuthenticationError, SATOSAProcessingHaltErro
 from .util.transaction_flow_logging import transaction_log
 from .error_description import ErrorDescription, ERROR_DESC, LOG_MSG
 
+from satosa.logging_util import satosa_logging
 logger = logging.getLogger('satosa')
 
 class InAcademiaBackend(SAMLBackend):
@@ -64,6 +65,7 @@ class InAcademiaBackend(SAMLBackend):
         # auth_response object will also be modified
         # import pdb; pdb.set_trace()
         internal_resp = super()._translate_response(auth_response, state)
+        satosa_logging(logger, logging.DEBUG, "Attributes received from IdP {} {}".format(auth_response.response.issuer.text, json.dumps([k for k in auth_response.ava.keys()])), state)
         resp_idp_entityid = internal_resp.to_dict().get('auth_info').get('issuer')
 
         if not any(affiliation_attr in auth_response.ava for affiliation_attr in self.config['affiliation_attributes']):


### PR DESCRIPTION
- [x] I updated the CHANGELOG.md

This commit adds a line that prints a list of received attributes from IdP so that we can inspect their conformance to InAcademia requirements.

```
[2020-11-27 12:30:06] [DEBUG]: [urn:uuid:b6507dcb-253a-4cba-a28e-b006a7571283] Attributes received from IdP https://idp1.inacademia.local/saml2/idp/metadata.php ["uid", "schacHomeOrganization", "eduPersonPrincipalName", "cn", "givenName", "sn", "displayName", "mail", "eduPersonAffiliation", "eduPersonScopedAffiliation", "isMemberOf"]
```
