### PR TITLE
Add idp_hint translation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to InAcademia SVS will be documented in this file.
 
 ## [Unreleased]
+## 2020-12-08
+- Add idp_hint translation logic
 
 ## [Released]
 ## 2.6.0
@@ -13,7 +15,7 @@ All notable changes to InAcademia SVS will be documented in this file.
 
 ## 2020-11-25
 ### Added
-- Error handling when a user requests 'persistent' scope but SVS is unable to construct/retrieve persistent user id for that user due to insufficient information from IdP. 
+- Error handling when a user requests 'persistent' scope but SVS is unable to construct/retrieve persistent user id for that user due to insufficient information from IdP.
 
 ## 2020-11-18
 ### Changed
@@ -23,7 +25,7 @@ All notable changes to InAcademia SVS will be documented in this file.
 
 ## 2020-11-13
 ### Added
-- Error handling against authentication error from IdP 
+- Error handling against authentication error from IdP
 
 ## 2020-11-24
 - Updated translations

--- a/example/inacademia_frontend.yaml.example
+++ b/example/inacademia_frontend.yaml.example
@@ -3,6 +3,7 @@ name: InAcademia
 config:
   signing_key_path: /var/svs/inAcademia.key
   client_db_path: /etc/cdb/cdb.json
+  translation_id_map_path: /var/svs/translations.yaml
   entity_id_map_path: /var/svs/entityids.json
   backend_name: InAcademiaBackend
   provider:

--- a/src/svs/assert_hint.py
+++ b/src/svs/assert_hint.py
@@ -32,16 +32,16 @@ class AssertHint(ResponseMicroService):
 
     def process(self, context, internal_response):
         idp_hint_key = context.state['InAcademia'].get('idp_hint_key', None)
-        real_idp_hint_key = context.state['InAcademia'].get('real_idp_hint_key', None)
-        logger.debug(f"AssertHint requested idp_hint: {idp_hint_key}, real_idp_hint: {real_idp_hint_key}")
+        fresh_idp_hint_key = context.state['InAcademia'].get('fresh_idp_hint_key', None)
+        logger.debug(f"AssertHint requested idp_hint: {idp_hint_key}, fresh_idp_hint: {fresh_idp_hint_key}")
 
-        if real_idp_hint_key is not None:
+        if fresh_idp_hint_key is not None:
             issuer = internal_response.auth_info.issuer
             logger.info(f"AssertHint issuer: {issuer}")
 
             issuer_hash = inacademia_hinting_hash(issuer)
             #logger.info(f"AssertHint issuer hash: {issuer_hash}")
-            if issuer_hash == real_idp_hint_key:
+            if issuer_hash == fresh_idp_hint_key:
                 internal_response.attributes[self.internal_attribute] = [idp_hint_key]
 
         return super().process(context, internal_response)

--- a/src/svs/assert_hint.py
+++ b/src/svs/assert_hint.py
@@ -28,17 +28,20 @@ class AssertHint(ResponseMicroService):
     def __init__(self, config, internal_attributes, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.internal_attribute = config.get('internal_attribute', 'idp_used')
-        logger.info("AssertHint micro_service is active %s" % self.internal_attribute)
+        logger.info(f"AssertHint micro_service is active {self.internal_attribute}")
 
     def process(self, context, internal_response):
         idp_hint_key = context.state['InAcademia'].get('idp_hint_key', None)
-        logger.debug("AssertHint requested idp_hint: %s" % idp_hint_key)
+        real_idp_hint_key = context.state['InAcademia'].get('real_idp_hint_key', None)
+        logger.debug(f"AssertHint requested idp_hint: {idp_hint_key}, real_idp_hint: {real_idp_hint_key}")
 
-        if idp_hint_key is not None:
+        if real_idp_hint_key is not None:
             issuer = internal_response.auth_info.issuer
-            logger.info("AssertHint issuer: %s" % issuer)
+            logger.info(f"AssertHint issuer: {issuer}")
 
             issuer_hash = inacademia_hinting_hash(issuer)
-            internal_response.attributes[self.internal_attribute] = [issuer_hash]
+            #logger.info(f"AssertHint issuer hash: {issuer_hash}")
+            if issuer_hash == real_idp_hint_key:
+                internal_response.attributes[self.internal_attribute] = [idp_hint_key]
 
         return super().process(context, internal_response)

--- a/src/svs/inacademia_frontend.py
+++ b/src/svs/inacademia_frontend.py
@@ -125,13 +125,11 @@ class InAcademiaFrontend(OpenIDConnectFrontend):
             except KeyError:
                 idp_hint_key = None
         if idp_hint_key:
-            logger.debug(f"received hint: {idp_hint_key}")
-            real_idp_hint_key = self._get_fresh_hint(idp_hint_key)
-            logger.debug(f"translated hint: {real_idp_hint_key}")
+            fresh_idp_hint_key = self._get_fresh_hint(idp_hint_key)
             context.state['InAcademia']['idp_hint_key'] = idp_hint_key
-            context.state['InAcademia']['real_idp_hint_key'] = real_idp_hint_key
-            entity_id = self.entity_id_map.get(real_idp_hint_key, None)
-            logger.debug(f"hinted entity_id: {entity_id}")
+            context.state['InAcademia']['fresh_idp_hint_key'] = fresh_idp_hint_key
+            entity_id = self.entity_id_map.get(fresh_idp_hint_key, None)
+            logger.debug({"received hint": idp_hint_key, "fresh hint": fresh_idp_hint_key, "mapped entityID": entity_id})
             if entity_id:
                 #Base64 encode the URL because SATOSA's saml2 backend expects it so
                 entity_id = urlsafe_b64encode(entity_id.encode('utf-8'))


### PR DESCRIPTION
- [x] I updated the CHANGELOG.md

This PR adds idp_hint translation logic to preserve compatibility with stale idp_hint hashes.

Requires new inacademia_frontend.yaml configuration option:
```translation_id_map_path: /var/svs/translations.yaml```
