### PR TITLE
Error handling for the cases when svs is unable to resolve entity_id metadata or SAML binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to InAcademia SVS will be documented in this file.
 
 ## [Unreleased]
+## 2020-12-28
+### Added
+- Error handling for the case when SVS is unable to retrieve metadata against the resolved idp entity_id
+- Error handling for the case when SVS is unable to resolve SAML binding of the resolved idp entity_id
+
 ## 2020-12-08
 - Add idp_hint translation logic
 

--- a/src/svs/error_description.py
+++ b/src/svs/error_description.py
@@ -31,3 +31,11 @@ class ErrorDescription(dict, Enum):
     FAILED_TO_CONSTRUCT_PERSISTENT_USERID = {
         ERROR_DESC: "error creating persistent identifier due to insufficient information from IdP",
         LOG_MSG: "Failed to construct persistent user id from IdP response."}
+
+    IDP_ENTITY_ID_METADATA_NOT_FOUND = {
+        ERROR_DESC: "entity_id error",
+        LOG_MSG: "IdP entity_id is not known to the MDX server."}
+
+    ERROR_IN_RESOLVING_SAML_BINDING = {
+        ERROR_DESC: "entity_id error",
+        LOG_MSG: "Encountered error while resolving SAML binding via MDX server."}

--- a/src/svs/error_description.py
+++ b/src/svs/error_description.py
@@ -36,6 +36,6 @@ class ErrorDescription(dict, Enum):
         ERROR_DESC: "entity_id error",
         LOG_MSG: "IdP entity_id is not known to the MDX server."}
 
-    ERROR_IN_RESOLVING_SAML_BINDING = {
+    FAILED_TO_CONSTRUCT_SAML_AUTHN_REQ = {
         ERROR_DESC: "entity_id error",
-        LOG_MSG: "Encountered error while resolving SAML binding via MDX server."}
+        LOG_MSG: "Failed to construct SAML authentication request."}

--- a/src/svs/inacademia_backend.py
+++ b/src/svs/inacademia_backend.py
@@ -59,10 +59,10 @@ class InAcademiaBackend(SAMLBackend):
         except SATOSAAuthenticationError:
             transaction_log(context.state, self.config.get("request_exit_order", 380),
                             "inacademia_backend", "request", "exit", "fail", '', '',
-                            ErrorDescription.ERROR_IN_RESOLVING_SAML_BINDING[LOG_MSG], 'mdx')
+                            ErrorDescription.FAILED_TO_CONSTRUCT_SAML_AUTHN_REQ[LOG_MSG], 'mdx')
 
             auth_error = SATOSAAuthenticationError(context.state, "")
-            auth_error._message = ErrorDescription.ERROR_IN_RESOLVING_SAML_BINDING[ERROR_DESC]
+            auth_error._message = ErrorDescription.FAILED_TO_CONSTRUCT_SAML_AUTHN_REQ[ERROR_DESC]
             raise auth_error
 
         transaction_log(context.state, self.config.get("request_exit_order", 400),

--- a/src/svs/inacademia_backend.py
+++ b/src/svs/inacademia_backend.py
@@ -56,14 +56,14 @@ class InAcademiaBackend(SAMLBackend):
 
         try:
             result = super().authn_request(context, entity_id)
-        except SATOSAAuthenticationError:
+        except SATOSAAuthenticationError as e:
             transaction_log(context.state, self.config.get("request_exit_order", 380),
                             "inacademia_backend", "request", "exit", "fail", '', '',
                             ErrorDescription.FAILED_TO_CONSTRUCT_SAML_AUTHN_REQ[LOG_MSG], 'mdx')
 
             auth_error = SATOSAAuthenticationError(context.state, "")
             auth_error._message = ErrorDescription.FAILED_TO_CONSTRUCT_SAML_AUTHN_REQ[ERROR_DESC]
-            raise auth_error
+            raise auth_error from e
 
         transaction_log(context.state, self.config.get("request_exit_order", 400),
                         "inacademia_backend", "request", "exit", "success", entity_id, '', 'Send request to IdP')


### PR DESCRIPTION
- [X] I updated the CHANGELOG.md
- Error handling for the case when SVS is unable to retrieve metadata against the resolved idp entity_id
- Error handling for the case when SVS is unable to resolve SAML binding of the resolved idp entity_id
